### PR TITLE
Add http response to CentrifugoException

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches:
       - 'main'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /vendor/
+.phpunit.result.cache
+composer.lock

--- a/Exception/CentrifugoErrorException.php
+++ b/Exception/CentrifugoErrorException.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Fresh\CentrifugoBundle\Exception;
 
 use Fresh\CentrifugoBundle\Model\CommandInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * CentrifugoErrorException.
@@ -22,14 +23,15 @@ use Fresh\CentrifugoBundle\Model\CommandInterface;
 class CentrifugoErrorException extends CentrifugoException
 {
     /**
-     * @param CommandInterface $command
-     * @param string           $message
-     * @param int              $code
-     * @param \Throwable|null  $previous
+     * @param CommandInterface  $command
+     * @param ResponseInterface $response
+     * @param string            $message
+     * @param int               $code
+     * @param \Throwable|null   $previous
      */
-    public function __construct(private readonly CommandInterface $command, string $message = '', int $code = 0, \Throwable $previous = null)
+    public function __construct(private readonly CommandInterface $command, ResponseInterface $response, string $message = '', int $code = 0, \Throwable $previous = null)
     {
-        parent::__construct($message, $code, $previous);
+        parent::__construct($response, $message, $code, $previous);
     }
 
     /**

--- a/Exception/CentrifugoException.php
+++ b/Exception/CentrifugoException.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Fresh\CentrifugoBundle\Exception;
 
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
 /**
  * CentrifugoException.
  *
@@ -19,4 +21,22 @@ namespace Fresh\CentrifugoBundle\Exception;
  */
 class CentrifugoException extends \Exception implements ExceptionInterface
 {
+    /**
+     * @param ResponseInterface $response
+     * @param string            $message
+     * @param int               $code
+     * @param \Throwable|null   $previous
+     */
+    public function __construct(private readonly ResponseInterface $response, string $message = '', int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return ResponseInterface
+     */
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
 }

--- a/Service/CentrifugoChecker.php
+++ b/Service/CentrifugoChecker.php
@@ -59,7 +59,7 @@ class CentrifugoChecker
     public function assertValidResponseStatusCode(ResponseInterface $response): void
     {
         if (Response::HTTP_OK !== $response->getStatusCode()) {
-            throw new CentrifugoException('Wrong status code for Centrifugo response');
+            throw new CentrifugoException($response, 'Wrong status code for Centrifugo response');
         }
     }
 
@@ -73,7 +73,7 @@ class CentrifugoChecker
         $headers = $response->getHeaders(false);
 
         if (!isset($headers['content-type'])) {
-            throw new CentrifugoException('Missing "content-type" header in Centrifugo response');
+            throw new CentrifugoException($response, 'Missing "content-type" header in Centrifugo response');
         }
     }
 
@@ -87,7 +87,7 @@ class CentrifugoChecker
         $headers = $response->getHeaders(false);
 
         if (!\in_array('application/json', $headers['content-type'], true)) {
-            throw new CentrifugoException('Unexpected content type for Centrifugo response');
+            throw new CentrifugoException($response, 'Unexpected content type for Centrifugo response');
         }
     }
 }

--- a/Tests/Exception/CentrifugoErrorExceptionTest.php
+++ b/Tests/Exception/CentrifugoErrorExceptionTest.php
@@ -18,6 +18,7 @@ use Fresh\CentrifugoBundle\Exception\ExceptionInterface;
 use Fresh\CentrifugoBundle\Model\CommandInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * CentrifugoErrorExceptionTest.
@@ -28,11 +29,14 @@ final class CentrifugoErrorExceptionTest extends TestCase
 {
     private CentrifugoErrorException $exception;
     private CommandInterface|MockObject $command;
+    private ResponseInterface|MockObject $response;
 
     protected function setUp(): void
     {
         $this->command = $this->createStub(CommandInterface::class);
-        $this->exception = new CentrifugoErrorException($this->command);
+        $this->response = $this->createStub(ResponseInterface::class);
+
+        $this->exception = new CentrifugoErrorException($this->command, $this->response);
     }
 
     protected function tearDown(): void
@@ -43,6 +47,11 @@ final class CentrifugoErrorExceptionTest extends TestCase
     public function testGetCommand(): void
     {
         self::assertSame($this->command, $this->exception->getCommand());
+    }
+
+    public function testGetResponse(): void
+    {
+        self::assertSame($this->response, $this->exception->getResponse());
     }
 
     public function testException(): void

--- a/Tests/Exception/CentrifugoExceptionTest.php
+++ b/Tests/Exception/CentrifugoExceptionTest.php
@@ -14,7 +14,9 @@ namespace Fresh\CentrifugoBundle\Tests\Exception;
 
 use Fresh\CentrifugoBundle\Exception\CentrifugoException;
 use Fresh\CentrifugoBundle\Exception\ExceptionInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * CentrifugoExceptionTest.
@@ -25,14 +27,23 @@ final class CentrifugoExceptionTest extends TestCase
 {
     private CentrifugoException $exception;
 
+    private ResponseInterface|MockObject $response;
+
     protected function setUp(): void
     {
-        $this->exception = new CentrifugoException();
+        $this->response = $this->createStub(ResponseInterface::class);
+
+        $this->exception = new CentrifugoException($this->response);
     }
 
     protected function tearDown(): void
     {
         unset($this->exception);
+    }
+
+    public function testGetResponse(): void
+    {
+        self::assertSame($this->response, $this->exception->getResponse());
     }
 
     public function testException(): void


### PR DESCRIPTION
Hi there!

In some cases client code would like to catch `CentrifugoException` and find out what's actually gone wrong. For instance, when `assertValidResponseStatusCode` throws exception, it just gives an error message and it's hard to find out the root cause or to log anything, since there's not that much context. Also, if trying to rely on symfony http client, AFAIK it doesn't log the actual responses, but writes just uri sting and response status code instead.

Therefore, this PR adds `ResponseInterface $response` property to `CentrifugoException` so that it may be caught by the client code and alalyzed somehow (for instance, logged).

Please, let me know what you think on this matter